### PR TITLE
Add DOCKER_GID example

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -56,6 +56,7 @@ services:
           LAVA_SERVER: lava_server:lava_port
           LAVA_TOKEN: lava_token
           LAVA_USER: lava_user
+          DOCKER_GID: your local docker GID
     environment:
         BUILDMASTER: master_ip
         BUILDMASTER_PORT: master_port


### PR DESCRIPTION
GBuildbot-worker need now a DOCKER_GID docker ARG, add it as example.
This patch is related to https://github.com/GKernelCI/GBuildbot-worker/pull/11