### PR TITLE
fix: auto-update submodules

### DIFF
--- a/.github/workflows/update-submodules.yaml
+++ b/.github/workflows/update-submodules.yaml
@@ -6,7 +6,7 @@ on:
       - ".github/workflows/update-submodules.yaml"
   workflow_dispatch: 
   schedule:
-    - cron: "0 4 * * 0" # 4 AM sunday UTC
+    - cron: "0 4 * * *" # 4 AM daily
 
 permissions:
   contents: write


### PR DESCRIPTION
https://github.com/GKernelCI/GKCI/issues/31

In the above issue, I wrote about the need for some form of automation that will update git submodules automatically.

<img width="1812" height="967" alt="2025-09-24-192717_grim" src="https://github.com/user-attachments/assets/de1f4063-0033-45ec-bbd8-991b2acfd630" />
<img width="1804" height="1336" alt="2025-09-24-192705_grim" src="https://github.com/user-attachments/assets/9116c7a4-0ba8-4f1d-8761-71bab830c148" />

To prove that this works, I ran it on my fork and verified that it does auto-commit updates to the submodules.

This solution is pretty simple, just automatically adds a commit on master once a week if there is a change.